### PR TITLE
add GHA release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: echo "value=$(node -e "console.log(require('./package.json').version)")" >> $GITHUB_OUTPUT
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="v${{ steps.version.outputs.value }}"
+
+          if gh release view "$VERSION" &>/dev/null; then
+            echo "Release $VERSION already exists, skipping."
+          else
+            gh release create "$VERSION" --title "$VERSION" --generate-notes
+          fi

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,41 @@
+name: Version Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        run: |
+          BASE_VERSION=$(git show origin/main:package.json | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).version))")
+          PR_VERSION=$(node -e "console.log(require('./package.json').version)")
+
+          echo "Base (main): $BASE_VERSION"
+          echo "PR:          $PR_VERSION"
+
+          if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
+            echo "❌ Version has not been bumped. Update the version in package.json before merging."
+            exit 1
+          fi
+
+          # Ensure PR version is strictly greater using node semver comparison
+          IS_GREATER=$(node -e "
+            const [aMaj, aMin, aPat] = '$PR_VERSION'.split('.').map(Number);
+            const [bMaj, bMin, bPat] = '$BASE_VERSION'.split('.').map(Number);
+            const greater = aMaj > bMaj || (aMaj === bMaj && aMin > bMin) || (aMaj === bMaj && aMin === bMin && aPat > bPat);
+            console.log(greater ? 'yes' : 'no');
+          ")
+
+          if [ "$IS_GREATER" != "yes" ]; then
+            echo "❌ PR version ($PR_VERSION) must be greater than base version ($BASE_VERSION)."
+            exit 1
+          fi
+
+          echo "✅ Version bumped: $BASE_VERSION → $PR_VERSION"

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -3,9 +3,11 @@ name: Version Check
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   check:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cadamsmith-web",
   "private": true,
-  "version": "3.0.0",
+  "version": "3.0.1",
   "type": "module",
   "scripts": {
     "dev": "astro dev",


### PR DESCRIPTION
Adds two GitHub Actions workflows:

- **version-check**: runs on non-draft PRs to main, fails if `package.json` version hasn't been bumped
- **release**: runs on push to main, creates a GitHub release tagged `v{version}` with auto-generated notes