### PR TITLE
resolve undici vulns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cadamsmith-web",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cadamsmith-web",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "dependencies": {
         "@fontsource-variable/rubik": "^5.2.5",
         "@fontsource/jetbrains-mono": "^5.2.5",
@@ -7421,9 +7421,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
-      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cadamsmith-web",
   "private": true,
-  "version": "3.1.1",
+  "version": "3.1.2",
   "type": "module",
   "scripts": {
     "dev": "astro dev",
@@ -30,6 +30,9 @@
     "svelte-check": "^4.0.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.20.0"
+  },
+  "overrides": {
+    "undici": "^7.24.7"
   },
   "dependencies": {
     "@fontsource-variable/rubik": "^5.2.5",


### PR DESCRIPTION
## Summary

- Adds an `overrides` entry in `package.json` to force `undici` to `^7.24.7`
- Resolves 4 open Dependabot alerts (3 moderate, 1 high) rooted in the `@astrojs/cloudflare` → `wrangler` → `miniflare` → `undici` dependency chain

## Why

`wrangler` (pulled in by `@astrojs/cloudflare`) was pinning `undici` to `7.14.0`, which is within the vulnerable range `7.0.0 - 7.23.0`. Patched versions exist at `7.24.x` but `wrangler` hadn't updated its constraint yet. The override forces the safe version until the upstream fix lands.