### PR TITLE
switch versioning from semver to calver with chat-ops bump command

### DIFF
--- a/.github/workflows/calver-bump.yml
+++ b/.github/workflows/calver-bump.yml
@@ -1,0 +1,73 @@
+name: CalVer Bump
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  bump:
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/bump') &&
+      (
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Get PR branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} --jq '.head.ref')
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.branch }}
+          fetch-depth: 0
+
+      - name: Calculate next CalVer
+        id: calver
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          YEAR=$(date -u +%Y)
+          MONTH=$(date -u +%m)
+          PREFIX="v${YEAR}.${MONTH}."
+
+          MAX_XX=$(gh release list --limit 100 --json tagName \
+            --jq "[.[] | .tagName | select(startswith(\"$PREFIX\")) | ltrimstr(\"$PREFIX\") | tonumber] | max // 0")
+
+          NEXT_XX=$(printf "%02d" $((MAX_XX + 1)))
+          VERSION="${YEAR}.${MONTH}.${NEXT_XX}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Update package.json
+        run: |
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = '${{ steps.calver.outputs.version }}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, '\t') + '\n');
+          "
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: bump version to ${{ steps.calver.outputs.version }}"
+          git push
+
+      - name: React to comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -X POST -f content='+1'

--- a/.github/workflows/calver-bump.yml
+++ b/.github/workflows/calver-bump.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+      reactions: write
     steps:
       - name: Get PR branch
         id: pr

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -40,20 +40,23 @@ jobs:
           echo "PR:          $PR_VERSION"
 
           if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
-            echo "❌ Version has not been bumped. Update the version in package.json before merging."
+            echo "❌ Version has not been bumped. Comment /bump on this PR to auto-calculate the next CalVer."
             exit 1
           fi
 
-          # Ensure PR version is strictly greater using node semver comparison
           IS_GREATER=$(node -e "
-            const [aMaj, aMin, aPat] = '$PR_VERSION'.split('.').map(Number);
-            const [bMaj, bMin, bPat] = '$BASE_VERSION'.split('.').map(Number);
-            const greater = aMaj > bMaj || (aMaj === bMaj && aMin > bMin) || (aMaj === bMaj && aMin === bMin && aPat > bPat);
-            console.log(greater ? 'yes' : 'no');
+            const parse = v => v.split('.').map(Number);
+            const pr = parse('$PR_VERSION');
+            const base = parse('$BASE_VERSION');
+            for (let i = 0; i < 3; i++) {
+              if (pr[i] > base[i]) { console.log('yes'); process.exit(0); }
+              if (pr[i] < base[i]) { console.log('no'); process.exit(0); }
+            }
+            console.log('no');
           ")
 
           if [ "$IS_GREATER" != "yes" ]; then
-            echo "❌ PR version ($PR_VERSION) must be greater than base version ($BASE_VERSION)."
+            echo "❌ PR version ($PR_VERSION) must be greater than base version ($BASE_VERSION). Comment /bump to recalculate."
             exit 1
           fi
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "cadamsmith-web",
 	"private": true,
-	"version": "3.2.1",
+	"version": "2026.04.01",
 	"type": "module",
 	"scripts": {
 		"dev": "astro dev",


### PR DESCRIPTION
## What

Replaces SemVer with CalVer (`YYYY.MM.XX`, counter resets monthly). Drops manual version bumps in favor of a `/bump` chat-ops command on PRs.

## Why

Tired of manually picking and typing version numbers. CalVer makes the version self-describing (date is inherently meaningful) and the bot handles the math.

## How it works

1. `version-check` GHA blocks merges when `package.json` version hasn't changed vs `main` (only fires when source files are touched — same conditional logic as before)
2. Comment `/bump` on a PR → bot lists existing GitHub releases to find the latest `vYYYY.MM.*` for the current month, increments the counter, commits updated `package.json` to the PR branch, reacts 👍
3. GitHub ruleset ("require up-to-date branch before merge") prevents race conditions — if two PRs both hold `2026.04.01`, whichever merges second must update from `main` first, version-check fails, `/bump` produces `2026.04.02`
4. `release.yml` unchanged — already works for any version string


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated version bumping triggered via `/bump` comment on pull requests
  * Enhanced version validation workflow with clearer error messages for version management
  * Updated package version to 2026.04.01

<!-- end of auto-generated comment: release notes by coderabbit.ai -->