### PR TITLE
fix: remove invalid reactions:write permission from calver-bump workflow

### DIFF
--- a/.github/workflows/calver-bump.yml
+++ b/.github/workflows/calver-bump.yml
@@ -18,7 +18,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-      reactions: write
     steps:
       - name: Get PR branch
         id: pr


### PR DESCRIPTION
`reactions` is not a valid GitHub Actions workflow permission scope — it was added by coderabbitai in #85 and caused the workflow to fail immediately with a parse error, preventing `/bump` from working at all.