### PR TITLE
use github app token for post-merge version bump push

### DIFF
--- a/.github/workflows/post-merge-bump.yml
+++ b/.github/workflows/post-merge-bump.yml
@@ -11,9 +11,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Calculate next CalVer
         id: calver


### PR DESCRIPTION
## Summary

Switches `post-merge-bump.yml` from a personal access token (`BOT_PAT`) to a GitHub App token so the version bump commit can bypass the main branch ruleset without relying on admin credentials.

- Uses `actions/create-github-app-token` to mint a short-lived token from the `cadamsmith-dev-bot` GitHub App before checkout
- The app is added as a bypass actor on the main branch ruleset, scoped only to this repo

## Prerequisites
- `BOT_APP_ID` and `BOT_APP_PRIVATE_KEY` secrets added to the repo
- `cadamsmith-dev-bot` app added to the main ruleset bypass list