### PR TITLE
fix: timeline items not showing + add production environment to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://cadamsmith.dev
     permissions:
       contents: read
     steps:

--- a/src/lib/components/Timeline.svelte
+++ b/src/lib/components/Timeline.svelte
@@ -38,7 +38,7 @@
 	<div class="timeline-panels">
 		{#each ['Work', 'Education'] as group (group)}
 			<div class="timeline-panel" class:selected={group === currentGroup}>
-				{#each timeline.filter((item) => item.group === group) as timelineItem (timelineItem.company)}
+				{#each timeline.filter((item) => item.group === group) as timelineItem (timelineItem.order)}
 					<div class="timeline-item">
 						<div class="timeline-item-left">
 							<div class="img-wrapper">


### PR DESCRIPTION
## Changes

- **Fix timeline items not showing** — changed the Svelte `{#each}` key from `timelineItem.company` to `timelineItem.order` in `Timeline.svelte`; duplicate company names were causing items to be deduplicated/hidden
- **Add production environment to deploy workflow** — adds `environment: name: production / url: https://cadamsmith.dev` to the deploy job so deployments appear in the GitHub repo sidebar