### PR TITLE
improve mobile responsiveness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "cadamsmith-web",
-	"version": "2026.04.08",
+	"version": "2026.04.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "cadamsmith-web",
-			"version": "2026.04.08",
+			"version": "2026.04.12",
 			"dependencies": {
 				"@astrojs/check": "^0.9.8",
 				"@fontsource-variable/rubik": "^5.2.5",
@@ -3531,21 +3531,6 @@
 				}
 			}
 		},
-		"node_modules/astro/node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"bin": {
-				"tsc": "bin/tsc",
-				"tsserver": "bin/tsserver"
-			},
-			"engines": {
-				"node": ">=14.17"
-			}
-		},
 		"node_modules/astro/node_modules/zod-to-ts": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/zod-to-ts/-/zod-to-ts-1.2.0.tgz",
@@ -7021,7 +7006,7 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
 			"integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@astrojs/compiler": "^2.9.1",
@@ -7444,7 +7429,7 @@
 			"version": "0.0.15",
 			"resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
 			"integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/sade": {
@@ -7485,7 +7470,7 @@
 			"version": "0.7.9",
 			"resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
 			"integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"suf-log": "^2.5.3"
@@ -7733,7 +7718,7 @@
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
 			"integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"s.color": "0.0.15"
@@ -8000,6 +7985,7 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/src/lib/components/MusicPlayer.svelte
+++ b/src/lib/components/MusicPlayer.svelte
@@ -1,9 +1,3 @@
-<script module>
-	// Module-level: persists across remounts (client-side navigations) but resets on full page load.
-	// On first hydration we keep the SSR-rendered song; on subsequent mounts we randomize.
-	let hasLoaded = false;
-</script>
-
 <script lang="ts">
 	import { onMount } from 'svelte';
 
@@ -12,19 +6,12 @@
 	let randomized: string[] = [];
 	let index = $state(0);
 	let isPlaying = $state(false);
+	let isMounted = $state(false);
 
 	onMount(() => {
-		if (hasLoaded) {
-			randomized = [...youTubeUrls].sort(() => Math.random() - 0.5);
-			index = getRandomIndex();
-		} else {
-			// Keep the SSR-rendered song (youTubeUrls[0]) at index 0 so the iframe src
-			// doesn't change on hydration. Shuffle the rest for next/prev navigation.
-			const [first, ...rest] = youTubeUrls;
-			randomized = [first, ...rest.sort(() => Math.random() - 0.5)];
-			index = 0;
-			hasLoaded = true;
-		}
+		randomized = [...youTubeUrls].sort(() => Math.random() - 0.5);
+		index = getRandomIndex();
+		isMounted = true;
 	});
 
 	function getRandomIndex() {
@@ -44,27 +31,29 @@
 	let url = $derived(randomized[index] ?? youTubeUrls[0]);
 </script>
 
-<div class="controls">
-	<button onclick={previousSong} aria-label="Previous Song">
-		<iconify-icon class="iconify-icon" icon="mdi:skip-previous"></iconify-icon>
-	</button>
+{#if isMounted}
+	<div class="controls">
+		<button onclick={previousSong} aria-label="Previous Song">
+			<iconify-icon class="iconify-icon" icon="mdi:skip-previous"></iconify-icon>
+		</button>
 
-	<iconify-icon class="iconify-icon music-icon" icon="mdi:music"></iconify-icon>
+		<iconify-icon class="iconify-icon music-icon" icon="mdi:music"></iconify-icon>
 
-	<button onclick={nextSong} aria-label="Next Song">
-		<iconify-icon class="iconify-icon" icon="mdi:skip-next"></iconify-icon>
-	</button>
-</div>
+		<button onclick={nextSong} aria-label="Next Song">
+			<iconify-icon class="iconify-icon" icon="mdi:skip-next"></iconify-icon>
+		</button>
+	</div>
 
-<iframe
-	width="344"
-	height="210"
-	src="{url}&controls=0&rel=0{isPlaying ? '&autoplay=1' : ''}"
-	title="YouTube video player"
-	frameborder="0"
-	allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-	referrerpolicy="strict-origin-when-cross-origin"
-></iframe>
+	<iframe
+		width="100%"
+		height="210"
+		src="{url}&controls=0&rel=0{isPlaying ? '&autoplay=1' : ''}"
+		title="YouTube video player"
+		frameborder="0"
+		allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+		referrerpolicy="strict-origin-when-cross-origin"
+	></iframe>
+{/if}
 
 <style>
 	.controls {

--- a/src/lib/components/SkillBadge.svelte
+++ b/src/lib/components/SkillBadge.svelte
@@ -22,6 +22,7 @@
 		flex-direction: row;
 		gap: 0.3rem;
 		align-items: center;
+		min-width: 0;
 
 		text-decoration: none;
 		color: #000;
@@ -43,11 +44,21 @@
 	}
 
 	.skill-badge span {
-		display: contents;
-		height: 100%;
+		flex: 1;
+		min-width: 0;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	@media (max-width: 600px) {
+		.skill-badge {
+			justify-content: center;
+		}
+
+		.skill-badge span {
+			display: none;
+		}
 	}
 
 	.skill-badge:hover,

--- a/src/lib/components/SkillsWidget.svelte
+++ b/src/lib/components/SkillsWidget.svelte
@@ -29,4 +29,10 @@
 		grid-gap: 0.4rem;
 		grid-auto-flow: dense;
 	}
+
+	@media (max-width: 600px) {
+		.skills-list {
+			grid-template-columns: repeat(4, 1fr);
+		}
+	}
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -180,7 +180,7 @@ const heroTags = heroTagEntries.sort((a, b) => a.data.order - b.data.order);
 				</div>
 			</div>
 			<div class="right">
-				<MusicPlayer youTubeUrls={songUrls} client:visible />
+				<MusicPlayer youTubeUrls={songUrls} client:only="svelte" />
 			</div>
 		</div>
 	</section>
@@ -213,8 +213,8 @@ const heroTags = heroTagEntries.sort((a, b) => a.data.order - b.data.order);
 			display: none;
 		}
 
-		.contact-split .right {
-			display: none;
+		.contact-split {
+			flex-direction: column;
 		}
 	}
 
@@ -282,5 +282,6 @@ const heroTags = heroTagEntries.sort((a, b) => a.data.order - b.data.order);
 
 	.contact-split .right {
 		margin-top: 1rem;
+		min-width: 350px;
 	}
 </style>


### PR DESCRIPTION
## What changed

- **Skills grid**: switches to a 4-column icon-only layout on mobile (≤600px) instead of a single long list; badges hide their text label and center the icon
- **Skill badges**: fixed text truncation — replaced `display: contents` with `flex: 1; min-width: 0` so ellipsis works correctly at narrow widths
- **Music player**: now shows on mobile (was hidden); iframe width changed to 100% so it doesn't overflow; desktop column width set to `min-width: 350px`
- **Music player**: randomizes the starting song on every page load instead of always showing the first track; toolbar and iframe are gated behind `isMounted` to prevent the wrong song flashing in before hydration