### PR TITLE
chore: simplify dependabot config and skip deploy for non-site changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,20 +8,32 @@ updates:
       day: 'monday'
       time: '06:00'
       timezone: 'America/New_York'
-    # Group patch and minor updates, majors get individual PRs
+    # Bundle all non-major updates into one PR; majors get individual PRs
     groups:
-      npm-patch:
-        update-types:
-          - 'patch'
-      npm-minor:
+      npm-non-major:
         update-types:
           - 'minor'
-    # Limit open PRs to avoid spam
+          - 'patch'
     open-pull-requests-limit: 5
     # Add labels to PRs
     labels:
       - 'dependencies'
     # Commit message prefix
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+
+  # GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '06:00'
+      timezone: 'America/New_York'
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
     commit-message:
       prefix: 'chore'
       include: 'scope'

--- a/.github/workflows/post-merge-bump.yml
+++ b/.github/workflows/post-merge-bump.yml
@@ -3,6 +3,16 @@ name: Post-Merge Version Bump
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'astro.config.ts'
+      - 'tsconfig.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.npmrc'
+      - '.nvmrc'
+      - '.env.cloudflare'
 
 jobs:
   bump:


### PR DESCRIPTION
- Bundle all non-major npm updates (minor + patch) into a single weekly PR instead of two separate groups
- Add `github-actions` ecosystem so action versions in `.github/workflows/` get bumped
- Skip version bump, release, and deploy when only non-site files change (docs, configs, workflows, etc.)