### PR TITLE
add open-source projects showcase section

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -61,4 +61,19 @@ const songs = defineCollection({
 	})
 });
 
-export const collections = { skills, timeline, songs, blurbs, heroTags };
+const projects = defineCollection({
+	loader: glob({ pattern: '**/*.md', base: './src/content/projects' }),
+	schema: z.object({
+		name: z.string(),
+		emoji: z.string(),
+		description: z.string(),
+		technologies: z.array(z.string()).min(1),
+		githubUrl: z.string(),
+		liveUrl: z.string(),
+		liveLabel: z.string(),
+		status: z.enum(['WIP', 'Stable', 'Archived']).optional(),
+		order: z.number()
+	})
+});
+
+export const collections = { skills, timeline, songs, blurbs, heroTags, projects };

--- a/src/content/projects/catan-board-generator.md
+++ b/src/content/projects/catan-board-generator.md
@@ -1,0 +1,10 @@
+---
+name: 'catan-board-generator'
+emoji: '🎲'
+description: 'A randomized Catan board generator that scores each layout on six balance metrics, so you can regenerate until you find a board worth playing.'
+technologies: ['JavaScript']
+githubUrl: 'https://github.com/cadamsmith/catan-board-generator'
+liveUrl: 'https://catanboard.app'
+liveLabel: 'Play live'
+order: 1
+---

--- a/src/content/projects/dino-validation.md
+++ b/src/content/projects/dino-validation.md
@@ -1,0 +1,11 @@
+---
+name: 'dino-validation'
+emoji: '🦖'
+description: 'A zero-dependency TypeScript port of jQuery Validation — same battle-tested rules, no jQuery, with both declarative HTML-attribute and programmatic JS APIs.'
+technologies: ['TypeScript']
+githubUrl: 'https://github.com/cadamsmith/dino-validation'
+liveUrl: 'https://www.npmjs.com/package/dino-validation'
+liveLabel: 'View on npm'
+status: 'WIP'
+order: 2
+---

--- a/src/content/projects/dragon-bundles.md
+++ b/src/content/projects/dragon-bundles.md
@@ -1,0 +1,10 @@
+---
+name: 'dragon-bundles'
+emoji: '🐉'
+description: 'A cross-runtime CSS/JS bundling library for ASP.NET — one API spans classic System.Web and modern ASP.NET Core, designed to make migrating between runtimes painless.'
+technologies: ['C#', 'ASP.NET']
+githubUrl: 'https://github.com/cadamsmith/dragon-bundles'
+liveUrl: 'https://www.nuget.org/packages/DragonBundles'
+liveLabel: 'View on NuGet'
+order: 0
+---

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+	import type { Project } from '$lib/types/Project';
+
+	interface Props {
+		project: Project;
+	}
+
+	let { project }: Props = $props();
+</script>
+
+<article class="project-card">
+	<div class="project-header">
+		<span class="project-emoji" aria-hidden="true">{project.emoji}</span>
+		<h3 class="project-name">{project.name}</h3>
+		{#if project.status}
+			<span class="status-pill status-{project.status.toLowerCase()}">
+				{project.status}
+			</span>
+		{/if}
+	</div>
+
+	<p class="project-description">{project.description}</p>
+
+	<ul class="tech-list" aria-label="Technologies">
+		{#each project.technologies as tech (tech)}
+			<li class="tech-pill">{tech}</li>
+		{/each}
+	</ul>
+
+	<div class="project-actions">
+		<a
+			class="action-btn code-btn"
+			href={project.githubUrl}
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			<iconify-icon class="iconify-icon" icon="mdi:code-tags"></iconify-icon>
+			<span>Code</span>
+		</a>
+		<a
+			class="action-btn live-btn"
+			href={project.liveUrl}
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			<iconify-icon class="iconify-icon" icon="mdi:open-in-new"></iconify-icon>
+			<span>{project.liveLabel}</span>
+		</a>
+	</div>
+</article>
+
+<style>
+	.project-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.85rem;
+		background-color: var(--color-i);
+		border: 1px solid var(--color-border);
+		border-radius: 10px;
+		padding: 1.25rem;
+		height: 100%;
+		position: relative;
+		overflow: hidden;
+		transition:
+			border-color 0.12s ease,
+			transform 0.12s ease,
+			box-shadow 0.12s ease;
+	}
+
+	.project-card::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 2px;
+		background: linear-gradient(90deg, var(--color-c), transparent);
+		opacity: 0;
+		transition: opacity 0.18s ease;
+	}
+
+	.project-card:hover,
+	.project-card:focus-within {
+		border-color: var(--color-h);
+		transform: translateY(-2px);
+		box-shadow: 0 8px 24px -12px rgba(64, 184, 240, 0.35);
+	}
+
+	.project-card:hover::before,
+	.project-card:focus-within::before {
+		opacity: 1;
+	}
+
+	.project-header {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+	}
+
+	.project-emoji {
+		font-size: 1.75rem;
+		line-height: 1;
+		flex-shrink: 0;
+	}
+
+	.project-name {
+		flex: 1;
+		font-size: 1.05rem;
+		font-weight: 600;
+		font-family: 'JetBrains Mono', monospace;
+		color: var(--color-l);
+		margin: 0;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.status-pill {
+		font-size: 0.7rem;
+		font-weight: 600;
+		letter-spacing: 0.05em;
+		text-transform: uppercase;
+		padding: 0.15rem 0.5rem;
+		border-radius: 999px;
+		flex-shrink: 0;
+	}
+
+	.status-wip {
+		background-color: rgba(212, 134, 10, 0.15);
+		color: #e6a040;
+		border: 1px solid rgba(212, 134, 10, 0.35);
+	}
+
+	.status-stable {
+		background-color: rgba(64, 184, 240, 0.12);
+		color: var(--color-c);
+		border: 1px solid rgba(64, 184, 240, 0.3);
+	}
+
+	.status-archived {
+		background-color: var(--color-j);
+		color: var(--color-muted);
+		border: 1px solid var(--color-border);
+	}
+
+	.project-description {
+		font-size: 0.92rem;
+		line-height: 1.5;
+		color: var(--color-l);
+		opacity: 0.85;
+		margin: 0;
+	}
+
+	.tech-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.tech-pill {
+		font-size: 0.75rem;
+		font-weight: 500;
+		padding: 0.2rem 0.55rem;
+		border-radius: 4px;
+		background-color: var(--color-j);
+		color: var(--color-muted);
+		border: 1px solid var(--color-border);
+	}
+
+	.project-actions {
+		display: flex;
+		gap: 0.5rem;
+		margin-top: auto;
+		padding-top: 0.25rem;
+	}
+
+	.action-btn {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.35rem;
+		padding: 0.45rem 0.7rem;
+		border-radius: 6px;
+		font-size: 0.85rem;
+		font-weight: 600;
+		text-decoration: none;
+		transition:
+			background-color 0.12s ease,
+			border-color 0.12s ease,
+			color 0.12s ease;
+	}
+
+	.code-btn {
+		background-color: transparent;
+		color: var(--color-l);
+		border: 1px solid var(--color-border);
+	}
+
+	.code-btn:hover,
+	.code-btn:focus {
+		border-color: var(--color-h);
+		color: var(--color-h);
+		text-decoration: none;
+	}
+
+	.live-btn {
+		background-color: var(--color-c);
+		color: #0c0b09;
+		border: 1px solid var(--color-c);
+	}
+
+	.live-btn:hover,
+	.live-btn:focus {
+		background-color: var(--color-h);
+		border-color: var(--color-h);
+		color: #0c0b09;
+		text-decoration: none;
+	}
+</style>

--- a/src/lib/components/ProjectsWidget.svelte
+++ b/src/lib/components/ProjectsWidget.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import type { Project } from '$lib/types/Project';
+	import ProjectCard from './ProjectCard.svelte';
+
+	interface Props {
+		projects: Project[];
+	}
+
+	let { projects }: Props = $props();
+</script>
+
+<div class="projects-grid">
+	{#each projects as project (project.name)}
+		<ProjectCard {project} />
+	{/each}
+</div>
+
+<style>
+	.projects-grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 1.25rem;
+	}
+
+	@media (max-width: 900px) {
+		.projects-grid {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+
+	@media (max-width: 600px) {
+		.projects-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/src/lib/types/Project.ts
+++ b/src/lib/types/Project.ts
@@ -1,0 +1,11 @@
+export interface Project {
+	name: string;
+	emoji: string;
+	description: string;
+	technologies: string[];
+	githubUrl: string;
+	liveUrl: string;
+	liveLabel: string;
+	status?: 'WIP' | 'Stable' | 'Archived';
+	order: number;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,8 +7,10 @@ import TerminalWidget from '../lib/components/TerminalWidget.svelte';
 import Timeline from '../lib/components/Timeline.svelte';
 import MusicPlayer from '../lib/components/MusicPlayer.svelte';
 import LocationMap from '../lib/components/LocationMap.svelte';
+import ProjectsWidget from '../lib/components/ProjectsWidget.svelte';
 import type { Skill } from '../lib/types/Skill';
 import type { TimelineItem } from '../lib/types/TimelineItem';
+import type { Project } from '../lib/types/Project';
 
 const now = new Date();
 
@@ -55,6 +57,11 @@ const yearsOfWorkExperience = Math.floor(totalWorkMonths / 6) / 2;
 
 const songEntries = await getCollection('songs', ({ data }) => data.enabled);
 const songUrls: string[] = songEntries.map((entry) => entry.data.youtubeEmbedUrl);
+
+const projectEntries = await getCollection('projects');
+const projects: Project[] = projectEntries
+	.map((entry) => ({ ...entry.data }))
+	.sort((a, b) => a.order - b.order);
 
 const heroBlurb = await getEntry('blurbs', 'hero');
 const { Content: HeroContent } = await render(heroBlurb!);
@@ -112,6 +119,11 @@ const heroTags = heroTagEntries.sort((a, b) => a.data.order - b.data.order);
 				<Timeline timeline={timeline} client:visible />
 			</div>
 		</div>
+	</section>
+	<section>
+		<h2>Projects</h2>
+
+		<ProjectsWidget projects={projects} client:visible />
 	</section>
 	<section>
 		<div class="contact-split">


### PR DESCRIPTION
## Summary

- Add a new `projects` content collection seeded with three flagship open-source repos: **dragon-bundles**, **catan-board-generator**, **dino-validation**
- New **Projects** section on the homepage between "My Journey" and "Contact Me", rendered as a responsive 3→2→1 column grid of cards
- Each card shows emoji + name + tech badges + a concise description, with two equal CTAs: **Code** (→ GitHub) and **Live** (→ npm / catanboard.app / NuGet)
- Visual language matches the existing palette (cyan accent on `--color-i` cards, hover lift + gradient top accent) — no new color tokens introduced
- Optional `status` field for `WIP` / `Stable` / `Archived` pills (currently only `WIP` on dino-validation)
- Structure scales by dropping more `.md` files into `src/content/projects/`
