### PR TITLE
make years of experience compute at client time

### DIFF
--- a/src/lib/workExperience.test.ts
+++ b/src/lib/workExperience.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { computeYearsOfExperience, computeExperienceBreakdown } from './workExperience';
+
+describe('computeYearsOfExperience', () => {
+	it('rounds a whole-year span to the nearest half year', () => {
+		const years = computeYearsOfExperience([
+			{ startDate: '2020-01-15', endDate: '2023-01-15' }
+		]);
+		expect(years).toBe(3);
+	});
+
+	it('rounds down to the nearest half year', () => {
+		const years = computeYearsOfExperience([
+			{ startDate: '2020-01-15', endDate: '2020-08-15' }
+		]);
+		expect(years).toBe(0.5);
+	});
+
+	it('sums multiple ranges', () => {
+		const years = computeYearsOfExperience([
+			{ startDate: '2020-01-15', endDate: '2021-01-15' },
+			{ startDate: '2022-06-15', endDate: '2022-12-15' }
+		]);
+		expect(years).toBe(1.5);
+	});
+
+	it('measures a PRESENT range against the supplied now', () => {
+		const now = new Date('2025-03-15');
+		const years = computeYearsOfExperience(
+			[{ startDate: '2024-03-15', endDate: 'PRESENT' }],
+			now
+		);
+		expect(years).toBe(1);
+	});
+});
+
+describe('computeExperienceBreakdown', () => {
+	it('breaks a PRESENT range down to years, months, and days', () => {
+		const now = new Date('2021-01-15');
+		const breakdown = computeExperienceBreakdown(
+			[{ startDate: '2020-01-15', endDate: 'PRESENT' }],
+			now
+		);
+		expect(breakdown).toBe('1 years, 0 months, 1 days');
+	});
+
+	it('sums multiple ranges into a single breakdown', () => {
+		const breakdown = computeExperienceBreakdown([
+			{ startDate: '2020-01-15', endDate: '2021-01-15' },
+			{ startDate: '2022-01-15', endDate: '2022-04-15' }
+		]);
+		expect(breakdown).toBe('1 years, 2 months, 31 days');
+	});
+});

--- a/src/lib/workExperience.ts
+++ b/src/lib/workExperience.ts
@@ -1,0 +1,41 @@
+export interface DateRange {
+	startDate: string;
+	endDate: string;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+function rangeEnd(endDate: string, now: Date): Date {
+	return endDate === 'PRESENT' ? now : new Date(endDate);
+}
+
+export function computeYearsOfExperience(
+	ranges: DateRange[],
+	now: Date = new Date()
+): number {
+	const totalMonths = ranges.reduce((sum, { startDate, endDate }) => {
+		const start = new Date(startDate);
+		const end = rangeEnd(endDate, now);
+		const months =
+			(end.getFullYear() - start.getFullYear()) * 12 +
+			(end.getMonth() - start.getMonth());
+		return sum + months;
+	}, 0);
+	return Math.floor(totalMonths / 6) / 2;
+}
+
+export function computeExperienceBreakdown(
+	ranges: DateRange[],
+	now: Date = new Date()
+): string {
+	const totalDays = ranges.reduce((sum, { startDate, endDate }) => {
+		const start = new Date(startDate);
+		const end = rangeEnd(endDate, now);
+		return sum + Math.floor((end.getTime() - start.getTime()) / MS_PER_DAY);
+	}, 0);
+	const years = Math.floor(totalDays / 365.25);
+	const remainingDays = totalDays - Math.floor(years * 365.25);
+	const months = Math.floor(remainingDays / 30.4375);
+	const days = remainingDays - Math.floor(months * 30.4375);
+	return `${years} years, ${months} months, ${days} days`;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,10 @@ import ProjectsWidget from '../lib/components/ProjectsWidget.svelte';
 import type { Skill } from '../lib/types/Skill';
 import type { TimelineItem } from '../lib/types/TimelineItem';
 import type { Project } from '../lib/types/Project';
+import {
+	computeYearsOfExperience,
+	computeExperienceBreakdown
+} from '../lib/workExperience';
 
 const now = new Date();
 
@@ -41,33 +45,9 @@ const timeline: TimelineItem[] = timelineEntries
 const latestWorkLocation = timeline.find((item) => item.group === 'Work')?.location ?? '';
 
 const workItems = timeline.filter((item) => item.group === 'Work');
-const totalWorkMonths = workItems
-	.flatMap((item) => item.dateRanges)
-	.reduce((sum, { startDate, endDate }) => {
-		const start = new Date(startDate);
-		const end = endDate === 'PRESENT' ? now : new Date(endDate);
-		const months =
-			(end.getFullYear() - start.getFullYear()) * 12 +
-			(end.getMonth() - start.getMonth());
-		return sum + months;
-	}, 0);
-const yearsOfWorkExperience = Math.floor(totalWorkMonths / 6) / 2;
-
-const msPerDay = 86_400_000;
-const totalWorkDays = workItems
-	.flatMap((item) => item.dateRanges)
-	.reduce((sum, { startDate, endDate }) => {
-		const start = new Date(startDate);
-		const end = endDate === 'PRESENT' ? now : new Date(endDate);
-		return sum + Math.floor((end.getTime() - start.getTime()) / msPerDay);
-	}, 0);
-const workExperienceYears = Math.floor(totalWorkDays / 365.25);
-const workExperienceRemainingDays =
-	totalWorkDays - Math.floor(workExperienceYears * 365.25);
-const workExperienceMonths = Math.floor(workExperienceRemainingDays / 30.4375);
-const workExperienceDays =
-	workExperienceRemainingDays - Math.floor(workExperienceMonths * 30.4375);
-const workExperienceBreakdown = `${workExperienceYears} years, ${workExperienceMonths} months, ${workExperienceDays} days`;
+const workDateRanges = workItems.flatMap((item) => item.dateRanges);
+const yearsOfWorkExperience = computeYearsOfExperience(workDateRanges, now);
+const workExperienceBreakdown = computeExperienceBreakdown(workDateRanges, now);
 
 const songEntries = await getCollection('songs', ({ data }) => data.enabled);
 const songUrls: string[] = songEntries.map((entry) => entry.data.youtubeEmbedUrl);
@@ -93,21 +73,24 @@ const heroTags = heroTagEntries.sort((a, b) => a.data.order - b.data.order);
 
 		<div class="hero-info-tag-list">
 			{
-				heroTags.map((tag) => (
-					<span
-						class="hero-info-tag"
-						data-tooltip={
-							tag.data.label.includes('{years}') ? workExperienceBreakdown : undefined
-						}
-					>
-						<iconify-icon class="iconify-icon" icon={tag.data.icon} />
-						<span class="hero-info-tag-text">
-							{tag.data.label
-								.replace('{years}', String(yearsOfWorkExperience))
-								.replace('{location}', latestWorkLocation)}
+				heroTags.map((tag) => {
+					const isYearsTag = tag.data.label.includes('{years}');
+					return (
+						<span
+							class="hero-info-tag"
+							data-tooltip={isYearsTag ? workExperienceBreakdown : undefined}
+							data-years-template={isYearsTag ? tag.data.label : undefined}
+							data-work-ranges={isYearsTag ? JSON.stringify(workDateRanges) : undefined}
+						>
+							<iconify-icon class="iconify-icon" icon={tag.data.icon} />
+							<span class="hero-info-tag-text">
+								{tag.data.label
+									.replace('{years}', String(yearsOfWorkExperience))
+									.replace('{location}', latestWorkLocation)}
+							</span>
 						</span>
-					</span>
-				))
+					);
+				})
 			}
 		</div>
 
@@ -176,6 +159,37 @@ const heroTags = heroTagEntries.sort((a, b) => a.data.order - b.data.order);
 		</div>
 	</section>
 </BaseLayout>
+
+<script>
+	import {
+		computeYearsOfExperience,
+		computeExperienceBreakdown,
+		type DateRange
+	} from '../lib/workExperience';
+
+	function refreshWorkExperience() {
+		const tag = document.querySelector<HTMLElement>('[data-work-ranges]');
+		if (!tag) return;
+
+		const rangesAttr = tag.getAttribute('data-work-ranges');
+		const template = tag.getAttribute('data-years-template');
+		if (!rangesAttr || !template) return;
+
+		const ranges = JSON.parse(rangesAttr) as DateRange[];
+		const now = new Date();
+
+		const textEl = tag.querySelector('.hero-info-tag-text');
+		if (textEl) {
+			textEl.textContent = template.replace(
+				'{years}',
+				String(computeYearsOfExperience(ranges, now))
+			);
+		}
+		tag.setAttribute('data-tooltip', computeExperienceBreakdown(ranges, now));
+	}
+
+	document.addEventListener('astro:page-load', refreshWorkExperience);
+</script>
 
 <style>
 	.hero h1 {


### PR DESCRIPTION
## Summary

The years-of-experience count and its hover tooltip were computed in the `index.astro` frontmatter with `new Date()`. Because the site builds to static output, that value was frozen at build time and went stale until the next deploy — most visibly the day-level tooltip breakdown (`"X years, Y months, Z days"`), which no reasonable rebuild cadence could keep accurate.

## Changes

- Extract the date math into `src/lib/workExperience.ts` (`computeYearsOfExperience`, `computeExperienceBreakdown`), replacing the duplicated two-pass computation in `index.astro`.
- Keep the build-time values as the SSR fallback, then recompute on the client on `astro:page-load` so the label and tooltip always track the visitor's current date.
- Add unit tests covering half-year rounding, multi-range summing, `PRESENT` handling, and the day-level breakdown.