### PR TITLE
Infinite-loop projects carousel + Building status badge

### DIFF
--- a/public/resume.pdf
+++ b/public/resume.pdf
@@ -518,12 +518,12 @@ xœ}¿KqÆ?×U–X94%MQKS†Nø#Ô¦óüQ vİ÷BšË¡©hˆFk	¢ÙÆú‚ !
 endstream
 endobj
 124 0 obj
-<</Title<FEFF004100640061006D00200053006D0069007400680020201400200052006500730075006D0065>/Author(Adam Smith)/Creator(Typst 0.15.0)/ModDate(D:20260704184033-04'00)/CreationDate(D:20260704184033-04'00)>>
+<</Title<FEFF004100640061006D00200053006D0069007400680020201400200052006500730075006D0065>/Author(Adam Smith)/Creator(Typst 0.15.0)/ModDate(D:20260712010604-04'00)/CreationDate(D:20260712010604-04'00)>>
 endobj
 125 0 obj
 <</Length 1166/Type/Metadata/Subtype/XML>>
 stream
-<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Adam Smith â€” Resume</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Adam Smith</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-04T18:40:33-04:00</xmp:ModifyDate><xmp:CreateDate>2026-07-04T18:40:33-04:00</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>Kw1znCmKcnCcjeRyAuwXHA==</xmpMM:InstanceID><xmpMM:DocumentID>g2zH8izUorfU0doOzSbjiw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Adam Smith â€” Resume</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Adam Smith</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.15.0</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-12T01:06:04-04:00</xmp:ModifyDate><xmp:CreateDate>2026-07-12T01:06:04-04:00</xmp:CreateDate><xmpTPg:NPages>1</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>hznK+0DYxVvZcKID6G3EXA==</xmpMM:InstanceID><xmpMM:DocumentID>g2zH8izUorfU0doOzSbjiw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 126 0 obj
@@ -659,7 +659,7 @@ xref
 0000044781 00000 n
 0000046025 00000 n
 trailer
-<</Size 127/Root 126 0 R/Info 124 0 R/ID[(g2zH8izUorfU0doOzSbjiw==)(Kw1znCmKcnCcjeRyAuwXHA==)]>>
+<</Size 127/Root 126 0 R/Info 124 0 R/ID[(g2zH8izUorfU0doOzSbjiw==)(hznK+0DYxVvZcKID6G3EXA==)]>>
 startxref
 46195
 %%EOF

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -81,8 +81,8 @@ const projects = defineCollection({
 		// Consumed only by tools/resume. Falls back to `technologies` when absent.
 		resumeTechnologies: z.array(z.string()).min(1).optional(),
 		githubUrl: z.string(),
-		liveUrl: z.string(),
-		liveLabel: z.string(),
+		liveUrl: z.string().optional(),
+		liveLabel: z.string().optional(),
 		status: z.enum(['WIP', 'Stable', 'Archived']).optional(),
 		order: z.number(),
 		includeInResume: z.boolean().optional()

--- a/src/content/projects/airfare-drift.md
+++ b/src/content/projects/airfare-drift.md
@@ -1,0 +1,9 @@
+---
+name: 'airfare-drift'
+emoji: '✈️'
+description: 'A governed, tested dimensional warehouse for one thin transatlantic air market (ATL–CMN) that flags when fares drift from a fitted booking-curve and seasonal baseline — a residual anomaly layer, not a "book now" tool.'
+technologies: ['BigQuery', 'Dataform', 'Python']
+githubUrl: 'https://github.com/cadamsmith/airfare-drift'
+status: 'WIP'
+order: 3
+---

--- a/src/content/projects/video-to-score.md
+++ b/src/content/projects/video-to-score.md
@@ -1,0 +1,9 @@
+---
+name: 'video-to-score'
+emoji: '🎹'
+description: 'A CLI that turns page-flip sheet-music videos into clean, printable PDF scores — it detects each distinct page as it advances, dedupes, crops to the notation, and assembles them into a single document.'
+technologies: ['Python']
+githubUrl: 'https://github.com/cadamsmith/video-to-score'
+status: 'WIP'
+order: 4
+---

--- a/src/lib/components/ProjectCard.svelte
+++ b/src/lib/components/ProjectCard.svelte
@@ -6,6 +6,18 @@
 	}
 
 	let { project }: Props = $props();
+
+	// Friendlier badge text; the enum value (WIP) stays the data + color key.
+	const statusLabels: Record<NonNullable<Project['status']>, string> = {
+		WIP: 'Building',
+		Stable: 'Stable',
+		Archived: 'Archived'
+	};
+
+	// Optional leading icon per status (construction symbol for in-progress work).
+	const statusIcons: Partial<Record<NonNullable<Project['status']>, string>> = {
+		WIP: 'mdi:hammer-wrench'
+	};
 </script>
 
 <article class="project-card">
@@ -14,7 +26,14 @@
 		<h3 class="project-name">{project.name}</h3>
 		{#if project.status}
 			<span class="status-pill status-{project.status.toLowerCase()}">
-				{project.status}
+				{#if statusIcons[project.status]}
+					<iconify-icon
+						class="status-icon"
+						icon={statusIcons[project.status]}
+						aria-hidden="true"
+					></iconify-icon>
+				{/if}
+				{statusLabels[project.status]}
 			</span>
 		{/if}
 	</div>
@@ -37,15 +56,17 @@
 			<iconify-icon class="iconify-icon" icon="mdi:code-tags"></iconify-icon>
 			<span>Code</span>
 		</a>
-		<a
-			class="action-btn live-btn"
-			href={project.liveUrl}
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			<iconify-icon class="iconify-icon" icon="mdi:open-in-new"></iconify-icon>
-			<span>{project.liveLabel}</span>
-		</a>
+		{#if project.liveUrl}
+			<a
+				class="action-btn live-btn"
+				href={project.liveUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				<iconify-icon class="iconify-icon" icon="mdi:open-in-new"></iconify-icon>
+				<span>{project.liveLabel}</span>
+			</a>
+		{/if}
 	</div>
 </article>
 
@@ -117,6 +138,9 @@
 	}
 
 	.status-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.28em;
 		font-size: 0.7rem;
 		font-weight: 600;
 		letter-spacing: 0.05em;
@@ -124,6 +148,10 @@
 		padding: 0.15rem 0.5rem;
 		border-radius: 999px;
 		flex-shrink: 0;
+	}
+
+	.status-icon {
+		font-size: 0.9rem;
 	}
 
 	.status-wip {

--- a/src/lib/components/ProjectsWidget.svelte
+++ b/src/lib/components/ProjectsWidget.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import type { Project } from '$lib/types/Project';
 	import ProjectCard from './ProjectCard.svelte';
 
@@ -7,30 +8,354 @@
 	}
 
 	let { projects }: Props = $props();
-</script>
 
-<div class="projects-grid">
-	{#each projects as project (project.name)}
-		<ProjectCard {project} />
-	{/each}
-</div>
+	const count = projects.length;
 
-<style>
-	.projects-grid {
-		display: grid;
-		grid-template-columns: repeat(3, 1fr);
-		gap: 1.25rem;
+	let rail = $state<HTMLDivElement>();
+	// `loop` = enough cards overflow the viewport that seamless wrapping makes sense.
+	// When true we render three copies of the set and keep the viewport parked in the
+	// middle copy, re-centering by exactly one set-width whenever scrolling settles.
+	let loop = $state(false);
+	let activeIndex = $state(0);
+
+	let settleTimer: ReturnType<typeof setTimeout> | undefined;
+	let recentering = false;
+
+	// Three copies while looping so there's a full set of runway on either side.
+	const copies = $derived(loop ? [0, 1, 2] : [0]);
+
+	function reducedMotion(): boolean {
+		return (
+			typeof window !== 'undefined' &&
+			window.matchMedia('(prefers-reduced-motion: reduce)').matches
+		);
 	}
 
-	@media (max-width: 900px) {
-		.projects-grid {
-			grid-template-columns: repeat(2, 1fr);
+	// Distance from one card to the next (card width + gap) — uniform across the rail.
+	function stride(): number {
+		if (!rail) return 0;
+		const items = rail.querySelectorAll<HTMLElement>('.rail-item');
+		if (items.length < 2) return items[0]?.offsetWidth ?? 0;
+		return items[1].offsetLeft - items[0].offsetLeft;
+	}
+
+	// Width of one full copy of the project set.
+	function setWidth(): number {
+		return stride() * count;
+	}
+
+	function measure(): boolean {
+		if (!rail) return false;
+		// Width of a single set: with clones present, that's scrollWidth / copies.length;
+		// without clones it's the rail's own scrollWidth.
+		const singleSet = rail.scrollWidth / copies.length;
+		return singleSet - rail.clientWidth > 1;
+	}
+
+	async function syncLoop(): Promise<void> {
+		if (!rail) return;
+		const shouldLoop = measure();
+		if (shouldLoop === loop) {
+			updateActive();
+			return;
+		}
+		loop = shouldLoop;
+		await tick();
+		if (loop && rail) {
+			recentering = true;
+			rail.scrollLeft = setWidth();
+			recentering = false;
+		}
+		updateActive();
+	}
+
+	function updateActive(): void {
+		if (!rail) return;
+		const step = stride();
+		if (!step) return;
+		const raw = Math.round(rail.scrollLeft / step);
+		activeIndex = loop ? ((raw % count) + count) % count : raw;
+	}
+
+	// Jump back into the middle copy by a whole set-width. Seamless because every copy
+	// is identical and the jump is an integer number of card strides.
+	function recenter(): void {
+		if (!rail || !loop) return;
+		const sw = setWidth();
+		if (!sw) return;
+		const left = rail.scrollLeft;
+		let next = left;
+		if (left < sw) next = left + sw;
+		else if (left >= 2 * sw) next = left - sw;
+		if (next !== left) {
+			recentering = true;
+			rail.scrollLeft = next;
+			recentering = false;
 		}
 	}
 
+	function onScroll(): void {
+		if (recentering) return;
+		updateActive();
+		if (!loop) return;
+		clearTimeout(settleTimer);
+		settleTimer = setTimeout(recenter, 120);
+	}
+
+	function page(direction: 1 | -1): void {
+		if (!rail) return;
+		// Re-normalize into the middle copy first so rapid clicks can never outrun the
+		// settle-based recenter and hit a hard edge — keeps the loop truly seamless.
+		recenter();
+		const distance = Math.max(rail.clientWidth * 0.85, stride());
+		rail.scrollBy({
+			left: direction * distance,
+			behavior: reducedMotion() ? 'auto' : 'smooth'
+		});
+	}
+
+	// Scroll to the nearest occurrence of a project index, staying inside the middle copy.
+	function goTo(index: number): void {
+		if (!rail) return;
+		const step = stride();
+		if (!step) return;
+		if (!loop) {
+			rail.scrollTo({
+				left: index * step,
+				behavior: reducedMotion() ? 'auto' : 'smooth'
+			});
+			return;
+		}
+		recenter();
+		const base = Math.round(rail.scrollLeft / step);
+		const currentBucket = Math.floor(base / count) * count;
+		// Pick whichever copy of `index` is closest to where we are now.
+		const candidates = [
+			currentBucket + index,
+			currentBucket + index - count,
+			currentBucket + index + count
+		];
+		const target = candidates.reduce((best, c) =>
+			Math.abs(c - base) < Math.abs(best - base) ? c : best
+		);
+		rail.scrollTo({ left: target * step, behavior: reducedMotion() ? 'auto' : 'smooth' });
+	}
+
+	$effect(() => {
+		syncLoop();
+		const onResize = () => syncLoop();
+		window.addEventListener('resize', onResize);
+		return () => {
+			window.removeEventListener('resize', onResize);
+			clearTimeout(settleTimer);
+		};
+	});
+</script>
+
+<div class="carousel" class:looping={loop}>
+	{#if loop}
+		<button
+			class="nav-arrow prev"
+			type="button"
+			onclick={() => page(-1)}
+			aria-label="Previous projects"
+		>
+			<iconify-icon class="iconify-icon" icon="mdi:chevron-left"></iconify-icon>
+		</button>
+	{/if}
+
+	<div class="rail" bind:this={rail} onscroll={onScroll}>
+		{#each copies as copy (copy)}
+			{#each projects as project (`${copy}-${project.name}`)}
+				<!-- Clone copies are inert: hidden from AT and removed from tab order -->
+				<div class="rail-item" inert={loop && copy !== 1}>
+					<ProjectCard {project} />
+				</div>
+			{/each}
+		{/each}
+	</div>
+
+	{#if loop}
+		<button
+			class="nav-arrow next"
+			type="button"
+			onclick={() => page(1)}
+			aria-label="Next projects"
+		>
+			<iconify-icon class="iconify-icon" icon="mdi:chevron-right"></iconify-icon>
+		</button>
+	{/if}
+</div>
+
+{#if loop}
+	<div class="rail-footer">
+		<div class="dots" role="tablist" aria-label="Project positions">
+			{#each projects as project, i (project.name)}
+				<button
+					class="dot"
+					class:active={i === activeIndex}
+					type="button"
+					onclick={() => goTo(i)}
+					role="tab"
+					aria-selected={i === activeIndex}
+					aria-label={`Go to ${project.name}`}
+				></button>
+			{/each}
+		</div>
+		<span class="counter" aria-hidden="true">
+			{String(activeIndex + 1).padStart(2, '0')} / {String(count).padStart(2, '0')}
+		</span>
+	</div>
+{/if}
+
+<style>
+	.carousel {
+		position: relative;
+		/* room for the arrows to sit just outside the cards */
+		margin: 0 -0.5rem;
+	}
+
+	.rail {
+		display: flex;
+		gap: 1.25rem;
+		overflow-x: auto;
+		scroll-snap-type: x mandatory;
+		scroll-padding-left: 0.5rem;
+		padding: 0.5rem;
+		/* hide scrollbar; the arrows + dots carry the affordance */
+		scrollbar-width: none;
+		-ms-overflow-style: none;
+	}
+
+	.rail::-webkit-scrollbar {
+		display: none;
+	}
+
+	/*
+	 * While looping there's always more content in both directions, so fade both edges.
+	 * These are static overlays on the (non-scrolling) carousel rather than a mask on the
+	 * rail: a mask on a scroll container forces a per-frame re-raster of the moving content
+	 * and visibly flickers sub-elements (the solid Live button, the icons) as you page.
+	 */
+	.carousel.looping::before,
+	.carousel.looping::after {
+		content: '';
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 3.5rem;
+		z-index: 1;
+		pointer-events: none;
+	}
+
+	.carousel.looping::before {
+		left: 0;
+		background: linear-gradient(to right, var(--color-surface), transparent);
+	}
+
+	.carousel.looping::after {
+		right: 0;
+		background: linear-gradient(to left, var(--color-surface), transparent);
+	}
+
+	.rail-item {
+		flex: 0 0 clamp(15rem, 80%, 19rem);
+		scroll-snap-align: start;
+	}
+
+	.nav-arrow {
+		position: absolute;
+		top: calc(50% - 1rem);
+		transform: translateY(-50%);
+		z-index: 2;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.5rem;
+		height: 2.5rem;
+		border-radius: 999px;
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-border);
+		color: var(--color-l);
+		font-size: 1.4rem;
+		cursor: pointer;
+		box-shadow: 0 6px 20px -8px rgba(0, 0, 0, 0.8);
+		transition:
+			background-color 0.14s ease,
+			border-color 0.14s ease,
+			color 0.14s ease;
+	}
+
+	.nav-arrow.prev {
+		left: -0.75rem;
+	}
+
+	.nav-arrow.next {
+		right: -0.75rem;
+	}
+
+	.nav-arrow:hover,
+	.nav-arrow:focus-visible {
+		background-color: var(--color-c);
+		border-color: var(--color-c);
+		color: #0c0b09;
+	}
+
+	.rail-footer {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.85rem;
+		margin-top: 1rem;
+	}
+
+	.dots {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.dot {
+		width: 0.5rem;
+		height: 0.5rem;
+		padding: 0;
+		border: none;
+		border-radius: 999px;
+		background-color: var(--color-border);
+		cursor: pointer;
+		transition:
+			width 0.18s ease,
+			background-color 0.18s ease;
+	}
+
+	.dot:hover {
+		background-color: var(--color-muted);
+	}
+
+	.dot.active {
+		width: 1.4rem;
+		background-color: var(--color-c);
+	}
+
+	.dot:focus-visible {
+		outline: 2px solid var(--color-h);
+		outline-offset: 2px;
+	}
+
+	.counter {
+		font-family: 'JetBrains Mono', monospace;
+		font-size: 0.72rem;
+		letter-spacing: 0.06em;
+		color: var(--color-muted);
+	}
+
 	@media (max-width: 600px) {
-		.projects-grid {
-			grid-template-columns: 1fr;
+		.rail-item {
+			flex-basis: 85%;
+		}
+
+		.nav-arrow {
+			display: none;
 		}
 	}
 </style>

--- a/src/lib/types/Project.ts
+++ b/src/lib/types/Project.ts
@@ -4,8 +4,8 @@ export interface Project {
 	description: string;
 	technologies: string[];
 	githubUrl: string;
-	liveUrl: string;
-	liveLabel: string;
+	liveUrl?: string;
+	liveLabel?: string;
 	status?: 'WIP' | 'Stable' | 'Archived';
 	order: number;
 }


### PR DESCRIPTION
Replaces the static three-column projects grid with a horizontal carousel that seamlessly loops once the project set overflows the viewport, and reworks the WIP status pill into a friendlier "Building" badge.

## Carousel

- `ProjectsWidget` now renders a scroll-snapping rail instead of a CSS grid.
- When enough cards overflow to make wrapping worthwhile (`measure()`), it renders three identical copies of the set and parks the viewport in the middle copy, re-centering by exactly one set-width whenever scrolling settles — so paging past either end is seamless.
- Below the overflow threshold it degrades to a plain single-copy scroller with no clones, arrows, or dots.
- Controls: prev/next arrows (hidden on mobile), position dots, and a `NN / NN` counter. Clone copies are marked `inert` so they stay out of the tab order and hidden from assistive tech.
- Honors `prefers-reduced-motion` (jumps instead of smooth-scrolling) and re-evaluates loop state on resize.

## Status badge

- The `WIP` enum now renders as a **Building** badge with a hammer-wrench icon; `Stable`/`Archived` keep their labels. The enum value stays the data + color key.

## Content & schema

- Adds two new WIP projects: `airfare-drift` and `video-to-score`.
- Makes `liveUrl` / `liveLabel` optional (schema + `Project` type); the Live button only renders when a `liveUrl` is present.
